### PR TITLE
make: allow LDFLAGS to be passed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ TDIR = test
 CC = gcc
 CFLAGS = -I$(IDIR) -I$(LDIR) -fPIC -Werror -Wall -Wextra -Wno-unused-parameter
 
-LIBS = -lm
+LIBS = $(LDFLAGS) -lm
 
 WASM_FUNCS = malloc pinetime_new pinetime_step pinetime_loop pinetime_get_st7789 st7789_read_screen st7789_is_sleeping memset_test
 


### PR DESCRIPTION
Allow the user to add linker flags to the make command by setting the `LDFLAGS` environment variable.

This allows to have the `capstone` library installed at a non-system-wide place and link to it.

```sh
LDFLAGS="-L../capstone-5.0.1/_install/lib/" make
```